### PR TITLE
Create TestScript.cs.meta

### DIFF
--- a/TestPackage/Runtime/TestScript.cs.meta
+++ b/TestPackage/Runtime/TestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2db1409d205747e4689efc0da6ac042e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Meta file created manually in an empty Unity project. This is just so I have a metafile associated when pulling a package into Unity project directly.